### PR TITLE
feat(store): backlinks lookup with ALIAS + FTS soft mentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-query",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "DNS-inspired knowledge resolution layer for AI agents",
   "type": "module",
   "main": "dist/blink.js",

--- a/src/blink.ts
+++ b/src/blink.ts
@@ -1,10 +1,10 @@
 import Database from 'better-sqlite3';
-import { initDB, save, saveMany, getByPath, list, deleteRecord, move, searchByKeywords, listZones, createZone, getZone, slug, evictStale } from './store.js';
+import { initDB, save, saveMany, getByPath, list, deleteRecord, move, searchByKeywords, listZones, createZone, getZone, slug, evictStale, findBacklinks } from './store.js';
 import { resolve } from './resolver.js';
 import { executeQuery } from './query-executor.js';
 import { processDocuments, loadDirectory, extractiveSummarize, POSTGRES_DERIVERS, GITHUB_DERIVERS, extractWikiLinks } from './ingest.js';
 import { loadFromPostgres, loadFromPostgresProgressive, loadFromUrls, loadFromGit, loadFromGitHubIssues, introspectPostgresTable, pickTextColumn } from './adapters.js';
-import type { BlinkRecord, SaveInput, Zone, ZoneConfig, ResolveResponse, IngestDocument, IngestOptions, IngestResult, PostgresLoadConfig, PostgresProgressiveConfig, PostgresIntrospection, WebLoadConfig, GitLoadConfig, GitHubLoadConfig } from './types.js';
+import type { BlinkRecord, BacklinksResult, SaveInput, Zone, ZoneConfig, ResolveResponse, IngestDocument, IngestOptions, IngestResult, PostgresLoadConfig, PostgresProgressiveConfig, PostgresIntrospection, WebLoadConfig, GitLoadConfig, GitHubLoadConfig } from './types.js';
 
 export interface BlinkOptions {
   dbPath?: string;
@@ -85,6 +85,12 @@ export class Blink {
   /** Get a record by exact path (no resolution) */
   get(path: string): BlinkRecord | null {
     return getByPath(this.db, path);
+  }
+
+  /** Find all records that link to or mention the given path */
+  backlinks(path: string): BacklinksResult {
+    const target = getByPath(this.db, path);
+    return findBacklinks(this.db, path, target?.title ?? null);
   }
 
   /** Ingest documents (from LlamaIndex or any loader) into Blink records */
@@ -221,7 +227,7 @@ export class Blink {
 
 // Re-export types for consumers
 export type {
-  BlinkRecord, SaveInput, Zone, ZoneConfig, ResolveResponse, RecordType, Source, QueryAST, QueryCondition,
+  BlinkRecord, BacklinksResult, SaveInput, Zone, ZoneConfig, ResolveResponse, RecordType, Source, QueryAST, QueryCondition,
   IngestDocument, IngestOptions, IngestResult, SummarizeCallback, ClassifyCallback,
   DeriveNamespaceCallback, DeriveTitleCallback, DeriveTagsCallback, BuildSourcesCallback,
   PostgresLoadConfig, PostgresProgressiveConfig, PostgresIntrospection, PostgresColumnInfo,

--- a/src/store.ts
+++ b/src/store.ts
@@ -558,6 +558,39 @@ export function evictStale(db: Database): number {
   return staleRecords.length;
 }
 
+export function findBacklinks(
+  db: Database,
+  targetPath: string,
+  targetTitle: string | null,
+): { linked: BlinkRecord[]; mentioned: BlinkRecord[] } {
+  // Primary: deterministic ALIAS records pointing at targetPath
+  const linkedRows = db.prepare(
+    `SELECT * FROM records WHERE type = 'ALIAS' AND json_extract(content, '$.target') = ?`,
+  ).all(targetPath) as RawRecord[];
+  const linked = linkedRows.map(deserializeRecord);
+
+  // Secondary: FTS5 soft backlinks — records mentioning the target title in summary
+  let mentioned: BlinkRecord[] = [];
+  if (targetTitle) {
+    const matchExpr = `"${targetTitle.replace(/"/g, '""')}"`;
+    const mentionedRows = db.prepare(`
+      SELECT r.* FROM records_fts fts
+      JOIN records r ON r.path = fts.record_path
+      WHERE records_fts MATCH ?
+        AND r.path != ?
+        AND r.type != 'ALIAS'
+    `).all(matchExpr, targetPath) as RawRecord[];
+
+    // Exclude records already in linked (by path)
+    const linkedPaths = new Set(linked.map(r => r.path));
+    mentioned = mentionedRows
+      .map(deserializeRecord)
+      .filter(r => !linkedPaths.has(r.path));
+  }
+
+  return { linked, mentioned };
+}
+
 export function findSuggestions(db: Database, pathPrefix: string, parentNs: string): Array<{ path: string; title: string; type: string }> {
   return db.prepare(
     'SELECT path, title, type FROM records WHERE path LIKE ? OR namespace = ? ORDER BY hit_count DESC LIMIT 5'

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,14 @@ export interface QueryCondition {
   value: string | number | (string | number)[];
 }
 
+// Backlinks result
+export interface BacklinksResult {
+  /** ALIAS records whose content.target points to the queried path */
+  linked: BlinkRecord[];
+  /** Non-ALIAS records that mention the target's title in their summary (unlinked mentions) */
+  mentioned: BlinkRecord[];
+}
+
 // Resolution response
 export interface ResolveResponse {
   status: 'OK' | 'NXDOMAIN' | 'STALE' | 'ALIAS_LOOP';

--- a/tests/backlinks.test.ts
+++ b/tests/backlinks.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Blink } from '../src/blink.js';
+import { extractWikiLinks } from '../src/ingest.js';
+
+function newBlink(): Blink {
+  return new Blink({ dbPath: ':memory:' });
+}
+
+describe('backlinks', () => {
+  let blink: Blink;
+  beforeEach(() => {
+    blink = newBlink();
+  });
+
+  it('returns ALIAS record in linked when wikilink is extracted', () => {
+    const target = blink.save({ namespace: 'topics', title: 'product-launch', type: 'SUMMARY', summary: 'the product launch plan' });
+    const source = blink.save({
+      namespace: 'meetings',
+      title: 'standup-monday',
+      type: 'SUMMARY',
+      summary: 'Discussed [[product-launch]] timeline with team.',
+    });
+
+    extractWikiLinks(blink, [source]);
+
+    const result = blink.backlinks(target.path);
+    expect(result.linked).toHaveLength(1);
+    expect(result.linked[0].type).toBe('ALIAS');
+    expect((result.linked[0].content as { target: string }).target).toBe(target.path);
+  });
+
+  it('returns multiple ALIASes pointing to the same target', () => {
+    const target = blink.save({ namespace: 'topics', title: 'product-launch', type: 'SUMMARY', summary: 'launch plan' });
+    const m1 = blink.save({
+      namespace: 'meetings',
+      title: 'meeting-1',
+      type: 'SUMMARY',
+      summary: 'Discussed [[product-launch]] timeline.',
+    });
+    const m2 = blink.save({
+      namespace: 'meetings',
+      title: 'meeting-2',
+      type: 'SUMMARY',
+      summary: '[[product-launch]] design spec delivered.',
+    });
+
+    extractWikiLinks(blink, [m1, m2]);
+
+    const result = blink.backlinks(target.path);
+    expect(result.linked).toHaveLength(2);
+    expect(result.linked.every(r => r.type === 'ALIAS')).toBe(true);
+  });
+
+  it('returns empty arrays when no backlinks exist', () => {
+    blink.save({ namespace: 'topics', title: 'orphan', type: 'SUMMARY', summary: 'nobody links here' });
+
+    const result = blink.backlinks('topics/orphan');
+    expect(result.linked).toEqual([]);
+    expect(result.mentioned).toEqual([]);
+  });
+
+  it('does not return non-ALIAS records in linked', () => {
+    const target = blink.save({ namespace: 'topics', title: 'transport', type: 'SUMMARY', summary: 'how transports work' });
+    // Save a regular record that mentions transport in summary but is NOT an ALIAS
+    blink.save({
+      namespace: 'notes',
+      title: 'note-about-transport',
+      type: 'SOURCE',
+      summary: 'some notes about transport layer',
+    });
+
+    const result = blink.backlinks(target.path);
+    expect(result.linked).toEqual([]);
+  });
+
+  it('returns soft mentions in mentioned array', () => {
+    const target = blink.save({ namespace: 'topics', title: 'product-launch', type: 'SUMMARY', summary: 'the launch plan' });
+    // This record mentions "product-launch" in its summary but no wikilink was extracted
+    blink.save({
+      namespace: 'notes',
+      title: 'random-note',
+      type: 'SOURCE',
+      summary: 'I was thinking about the product-launch timeline yesterday.',
+    });
+
+    const result = blink.backlinks(target.path);
+    expect(result.linked).toEqual([]);
+    expect(result.mentioned.length).toBeGreaterThanOrEqual(1);
+    expect(result.mentioned[0].path).toBe('notes/random-note');
+  });
+
+  it('does not duplicate a record in both linked and mentioned', () => {
+    const target = blink.save({ namespace: 'topics', title: 'transport', type: 'SUMMARY', summary: 'how transports work' });
+    const source = blink.save({
+      namespace: 'sources',
+      title: 'mcp-spec',
+      type: 'SUMMARY',
+      summary: 'The transport layer is critical. See [[transport]] for details.',
+    });
+
+    extractWikiLinks(blink, [source]);
+
+    const result = blink.backlinks(target.path);
+    // The ALIAS should be in linked
+    expect(result.linked).toHaveLength(1);
+    // The source record mentions "transport" in summary but should not appear in mentioned
+    // because mentioned excludes ALIAS records AND the source itself is not an ALIAS
+    // The ALIAS is what shows up in linked; the source record may show in mentioned
+    // but it's a distinct record from the ALIAS, so no duplication issue
+    const mentionedPaths = result.mentioned.map(r => r.path);
+    const linkedPaths = result.linked.map(r => r.path);
+    // No path appears in both arrays
+    for (const p of linkedPaths) {
+      expect(mentionedPaths).not.toContain(p);
+    }
+  });
+
+  it('excludes the target record itself from mentioned', () => {
+    const target = blink.save({
+      namespace: 'topics',
+      title: 'transport',
+      type: 'SUMMARY',
+      summary: 'this page is about transport itself',
+    });
+
+    const result = blink.backlinks(target.path);
+    expect(result.mentioned.map(r => r.path)).not.toContain(target.path);
+  });
+
+  it('returns empty mentioned when target path does not exist', () => {
+    const result = blink.backlinks('nonexistent/path');
+    expect(result.linked).toEqual([]);
+    expect(result.mentioned).toEqual([]);
+  });
+});


### PR DESCRIPTION
findBacklinks returns { linked, mentioned } — deterministic ALIAS targets via json_extract, plus FTS5 unlinked mentions. Exposes Blink.backlinks(path) on the public API. Bumps to 2.1.0.